### PR TITLE
Fix #2, make comments act like docblock for SpaceAroundControlStructures

### DIFF
--- a/src/phpf.php
+++ b/src/phpf.php
@@ -11622,26 +11622,6 @@ EOT;
 				case T_CONSTANT_ENCAPSED_STRING:
 					$this->appendCode( $text );
 					break;
-				case T_COMMENT:
-					$isComment = false;
-					if (
-						 ! $this->leftUsefulTokenIs( [T_OPEN_TAG] ) &&
-						$this->rightTokenIs( [
-							T_IF,
-							T_DO,
-							T_FOR,
-							T_FOREACH,
-							T_SWITCH,
-							T_WHILE,
-							T_COMMENT,
-							T_DOC_COMMENT,
-						] )
-					) {
-						$this->appendCode( $this->newLine );
-						$isComment = true;
-					}
-					$this->appendCode( $text );
-					break;
 				case T_IF:
 				case T_DO:
 				case T_FOR:


### PR DESCRIPTION
It currently makes the normal comments act like DocBlocks, which means they are correctly indented, and there is a space between the comments and the control structure. Maybe we might want to change that later? Stick the comments/DocBlocks to the control structure and add a new line on top of the comments itself (from what I've seen, not even sure it's easily doable).